### PR TITLE
Add unittest for HTML content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# hello-world
+
+This repository contains a simple `index.html` page.
+
+## Running the tests
+
+The project includes a unit test verifying that the `<p>` tag in
+`index.html` contains exactly `hello world`.
+
+To run the test:
+
+```bash
+python3 -m unittest test_index.py
+```

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
 <body>
-<p>helloooo world
+<p>hello world
 </p>
 </body>

--- a/test_index.py
+++ b/test_index.py
@@ -1,0 +1,31 @@
+import unittest
+from html.parser import HTMLParser
+
+class PTagParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.in_p = False
+        self.text = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'p':
+            self.in_p = True
+
+    def handle_endtag(self, tag):
+        if tag == 'p':
+            self.in_p = False
+
+    def handle_data(self, data):
+        if self.in_p:
+            self.text.append(data.strip())
+
+class TestIndex(unittest.TestCase):
+    def test_p_contains_hello_world(self):
+        with open('index.html', encoding='utf-8') as f:
+            parser = PTagParser()
+            parser.feed(f.read())
+        p_text = ' '.join(parser.text).strip()
+        self.assertEqual(p_text, 'hello world')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update index.html with proper text
- add a unit test using html.parser
- document how to run tests in README

## Testing
- `python3 -m unittest test_index.py`

------
https://chatgpt.com/codex/tasks/task_e_684eb1147240832585fd5263be17fad3